### PR TITLE
Client-Server Model Hometask #1

### DIFF
--- a/src/app/category/category.controller.ts
+++ b/src/app/category/category.controller.ts
@@ -24,8 +24,8 @@ import { CategoryService } from './category.service'
 import { ValidationPipe } from '../../core/pipes'
 import { PaginationSearchParams } from '../../core/utils/params'
 
-@Controller('category')
-@ApiTags('category')
+@Controller('categories')
+@ApiTags('categories')
 export class CategoryController {
   constructor(private categoryService: CategoryService) {}
 

--- a/src/app/product/product.controller.ts
+++ b/src/app/product/product.controller.ts
@@ -25,7 +25,7 @@ import { ValidationPipe } from '../../core/pipes'
 import { FilterParams, PaginationSearchParams } from '../../core/utils/params'
 
 @Controller('products')
-@ApiTags('product')
+@ApiTags('products')
 export class ProductController {
   constructor(private productService: ProductService) {}
 


### PR DESCRIPTION
Ревью на соответствие принципам REST.

![image](https://user-images.githubusercontent.com/26006369/128417622-25e083fb-05f0-46e9-80f8-811bc17c7ae0.png)

### Products

- GET ​`/api​/products`
  - [x] URI Structure (пример: `/api/products?offset=0&limit=10&inStock=true`)
  - [x] HTTP Verbs (GET)
  - [x] Status codes (200 и 404)
- POST ​`/api​/products`
  - [x] URI Structure
  - [x] HTTP Verbs (POST)
  - [x] Status codes (201 и 400)
- GET ​`/api​/products​/{id}`
  - [x] URI Structure (пример: `/api/products/1`)
  - [x] HTTP Verbs (GET)
  - [x] Status codes (200, 400 (если ерунду какую-нибудь в `id` написать) и 404)
 - PUT ​`/api​/products​/{id}`
   - [x] URI Structure
   - [x] HTTP Verbs (PUT)
   - [x] Status codes (200, 400 и 404)
- DELETE ​`/api​/products​/{id}`
   - [x] URI Structure
   - [x] HTTP Verbs (DELETE)
   - [x] Status codes (200, 400 и 404)

### Categories

И тут я поняла, что не соблюдается принцип единообразия — у одного эндпоинта энтити во множественном числе, у второго — в единственном. В целом, REST-принципов это вроде бы никаких не нарушает, просто такое вот наблюдение.

- GET ​`/api​/category`
  - [x] URI Structure (пример: `/api/category?offset=0&limit=10&search=aaaa`)
  - [x] HTTP Verbs (GET)
  - [x] Status codes (200 и 404)
- POST ​`/api​/category`
  - [x] URI Structure
  - [x] HTTP Verbs (POST)
  - [x] Status codes (201 и 400)
- GET ​`/api​/category​/{id}`
  - [x] URI Structure (пример: `/api/category/1`)
  - [x] HTTP Verbs (GET)
  - [x] Status codes (200, 400 и 404)
 - PUT ​`/api​/category​/{id}`
   - [x] URI Structure
   - [x] HTTP Verbs (PUT)
   - [x] Status codes (200, 400 и 404)
- DELETE ​`/api​/category​/{id}`
   - [x] URI Structure
   - [x] HTTP Verbs (DELETE)
   - [x] Status codes (200, 400 и 404)